### PR TITLE
Support encrypted assertions

### DIFF
--- a/lib/mumukit/login/provider/saml.rb
+++ b/lib/mumukit/login/provider/saml.rb
@@ -15,6 +15,7 @@ class Mumukit::Login::Provider::Saml < Mumukit::Login::Provider::Base
                       idp_slo_target_url: saml_config.idp_slo_target_url,
                       slo_default_relay_state: saml_config.base_url,
                       idp_cert: File.read('./saml.crt'),
+                      private_key: File.read('./saml.pem'),
                       attribute_service_name: 'Mumuki',
                       request_attributes: [
                           {name: 'email', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Email address'},


### PR DESCRIPTION
Lo bueno es que al parecer andaba lo de desencriptar las aserciones en omniauth-saml. Estaría probando mal, o no sé, no lo descubrí aún :/. Así que no hay que monkeypatchear.

Lo malo es que con la última versión de labo no anda el logout (tira `SimpleSAML_Error_Exception: Validation of received messages enabled, but no signature found on message`). Todavía tengo que verlo porque con la anterior que antes estaba en docker andaba. @flbulgarelli se cambió algo del logout?