### PR TITLE
Fix certificates

### DIFF
--- a/lib/mumukit/login/provider/saml.rb
+++ b/lib/mumukit/login/provider/saml.rb
@@ -14,7 +14,8 @@ class Mumukit::Login::Provider::Saml < Mumukit::Login::Provider::Base
                       idp_sso_target_url: saml_config.idp_sso_target_url,
                       idp_slo_target_url: saml_config.idp_slo_target_url,
                       slo_default_relay_state: saml_config.base_url,
-                      idp_cert: File.read('./saml.crt'),
+                      idp_cert: File.read('./saml_idp.crt'),
+                      certificate: File.read('./saml.crt'),
                       private_key: File.read('./saml.pem'),
                       attribute_service_name: 'Mumuki',
                       request_attributes: [

--- a/lib/mumukit/login/provider/saml.rb
+++ b/lib/mumukit/login/provider/saml.rb
@@ -16,7 +16,7 @@ class Mumukit::Login::Provider::Saml < Mumukit::Login::Provider::Base
                       slo_default_relay_state: saml_config.base_url,
                       idp_cert: File.read('./saml_idp.crt'),
                       certificate: File.read('./saml.crt'),
-                      private_key: File.read('./saml.pem'),
+                      private_key: File.read('./saml.key'),
                       attribute_service_name: 'Mumuki',
                       request_attributes: [
                           {name: 'email', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Email address'},

--- a/lib/mumukit/login/version.rb
+++ b/lib/mumukit/login/version.rb
@@ -1,5 +1,5 @@
 module Mumukit
   module Login
-    VERSION = "1.2.0"
+    VERSION = "1.2.1"
   end
 end


### PR DESCRIPTION
Esto es lo que nos habló Sergio ayer de usar tres certificados.

Mumuki debe tener:
- Su .crt propio
- Su .key propio
- El .crt del IdP

Del lado del IdP lo mismo: su crt, su .key, y el .crt del SP