### PR TITLE
added terms and conditions into Auth0 lock

### DIFF
--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -1,0 +1,3 @@
+---
+en:
+  accept_terms_and_conditions: I accept the <a href=\"%{terms_url}/en.html\" target=\"_new\">terms and conditions</a>

--- a/lib/locales/es.yml
+++ b/lib/locales/es.yml
@@ -1,0 +1,3 @@
+---
+es:
+  accept_terms_and_conditions: Acepto los <a href=\"%{terms_url}/es.html\" target=\"_new\">términos y condiciones</a>

--- a/lib/mumukit/login.rb
+++ b/lib/mumukit/login.rb
@@ -9,6 +9,8 @@ require 'mumukit/core'
 require 'mumukit/auth'
 require 'mumukit/platform'
 
+I18n.load_translations_path File.join(__dir__, '..', 'locales', '*.yml')
+
 module Mumukit::Login
   def self.configure
     @config ||= defaults
@@ -18,6 +20,7 @@ module Mumukit::Login
   def self.defaults
     struct.tap do |config|
       config.logo_url = ENV['MUMUKI_LOGO_URL'] || "https://mumuki.io/static/logo.png"
+      config.terms_url = ENV['MUMUKI_TERMS_URL'] || "https://mumuki.io/static/terms"
       config.mucookie_domain = ENV['MUMUKI_COOKIES_DOMAIN'] || ENV['MUMUKI_MUCOOKIE_DOMAIN']
       config.mucookie_secret_key = ENV['SECRET_KEY_BASE'] || ENV['MUMUKI_MUCOOKIE_SECRET_KEY']
       config.mucookie_secret_salt = ENV['MUMUKI_MUCOOKIE_SECRET_SALT'] || 'mucookie secret salt'

--- a/lib/mumukit/login/settings.rb
+++ b/lib/mumukit/login/settings.rb
@@ -36,8 +36,10 @@ class Mumukit::Login::Settings
   def lock_json
     {
         languageDictionary: {
-            title: 'Mumuki'
+            title: 'Mumuki',
+            signUpTerms: I18n.t(:accept_terms_and_conditions, terms_url: Mumukit::Login.config.terms_url)
         },
+        mustAcceptTerms: true,
         language: I18n.locale,
         allowedConnections: lock_login_methods,
         socialButtonStyle: many_methods? ? 'small' : 'big',


### PR DESCRIPTION
We need still to write our Terms of service and create an endpoint in e.g. `https://mumuki.io/static/terms/(en|es|language).html`