### PR TITLE
Preserving querystring in login redirects

### DIFF
--- a/lib/mumukit/login/provider/base.rb
+++ b/lib/mumukit/login/provider/base.rb
@@ -14,10 +14,7 @@ class Mumukit::Login::Provider::Base
   end
 
   def login_path(controller)
-    create_uri(
-        "/login",
-        { origin: create_uri(controller.request.path, controller.request.params) }
-    )
+    create_uri '/login', origin: create_uri(controller.request.path, controller.request.params)
   end
 
   def auth_path
@@ -48,7 +45,7 @@ class Mumukit::Login::Provider::Base
 
   def create_uri(path, query_values)
     uri = Addressable::URI.heuristic_parse path
-    uri.query_values = query_values if query_values && !query_values.empty?
+    uri.query_values = query_values if query_values.present?
     uri.to_s
   end
 end

--- a/lib/mumukit/login/provider/base.rb
+++ b/lib/mumukit/login/provider/base.rb
@@ -14,7 +14,10 @@ class Mumukit::Login::Provider::Base
   end
 
   def login_path(controller)
-    "/login?origin=#{controller.request.path}"
+    create_uri(
+        "/login",
+        { origin: create_uri(controller.request.path, controller.request.params) }
+    )
   end
 
   def auth_path
@@ -39,5 +42,13 @@ class Mumukit::Login::Provider::Base
 
   def header_html(*)
     nil
+  end
+
+  private
+
+  def create_uri(path, query_values)
+    uri = Addressable::URI.heuristic_parse path
+    uri.query_values = query_values if query_values && !query_values.empty?
+    uri.to_s
   end
 end

--- a/spec/mumukit/provider_spec.rb
+++ b/spec/mumukit/provider_spec.rb
@@ -5,8 +5,7 @@ describe Mumukit::Login::Provider do
   let(:provider) { Mumukit::Login.config.provider }
   let(:login_settings) { Mumukit::Login::Settings.new }
 
-  before { allow(controller).to receive(:request).and_return(struct path: path, params: params) }
-  let(:path) { '/foo' }
+  before { allow(controller).to receive(:request).and_return(struct path: '/foo', params: params) }
   let(:params) { {} }
 
   describe Mumukit::Login::Provider::Developer do

--- a/spec/mumukit/provider_spec.rb
+++ b/spec/mumukit/provider_spec.rb
@@ -5,14 +5,22 @@ describe Mumukit::Login::Provider do
   let(:provider) { Mumukit::Login.config.provider }
   let(:login_settings) { Mumukit::Login::Settings.new }
 
-  before { allow(controller).to receive(:request).and_return(struct path: '/foo') }
+  before { allow(controller).to receive(:request).and_return(struct path: path, params: params) }
+  let(:path) { '/foo' }
+  let(:params) { {} }
 
   describe Mumukit::Login::Provider::Developer do
     let(:provider) { Mumukit::Login::Provider::Developer.new }
 
-    it { expect(provider.button_html(controller, 'login', 'clazz')).to eq '<a class="clazz" href="/login?origin=/foo">login</a>' }
+    it { expect(provider.button_html(controller, 'login', 'clazz')).to eq '<a class="clazz" href="/login?origin=%2Ffoo">login</a>' }
     it { expect(provider.header_html(controller)).to be_blank }
     it { expect(provider.footer_html(controller)).to be_blank }
+
+    describe "with querystring" do
+      let(:params) { { embed: true } }
+
+      it { expect(provider.button_html(controller, 'login', 'clazz')).to eq '<a class="clazz" href="/login?origin=%2Ffoo%3Fembed%3Dtrue">login</a>' }
+    end
   end
 
   describe Mumukit::Login::Provider::Auth0 do
@@ -21,7 +29,7 @@ describe Mumukit::Login::Provider do
 
     before { allow(controller).to receive(:url_for).with('/auth/auth0/callback').and_return('http://localmumuki.io/auth/auth0/callback') }
 
-    it { expect(provider.button_html(controller, 'login', 'clazz')).to eq '<a class="clazz" href="/login?origin=/foo">login</a>' }
+    it { expect(provider.button_html(controller, 'login', 'clazz')).to eq '<a class="clazz" href="/login?origin=%2Ffoo">login</a>' }
     it { expect(provider.header_html(controller, login_settings)).to be_present }
     it { expect(provider.header_html(controller, login_settings)).to include 'https://cdn.auth0.com/js/lock/11.5.2/lock.min.js' }
     it { expect(provider.header_html(controller, login_settings)).to_not include 'http://localmumuki.io/auth/auth0/callback' }
@@ -34,7 +42,7 @@ describe Mumukit::Login::Provider do
   describe Mumukit::Login::Provider::Saml do
     let(:provider) { Mumukit::Login::Provider::Saml.new }
 
-    it { expect(provider.button_html(controller, 'login', 'clazz')).to eq '<a class="clazz" href="/login?origin=/foo">login</a>' }
+    it { expect(provider.button_html(controller, 'login', 'clazz')).to eq '<a class="clazz" href="/login?origin=%2Ffoo">login</a>' }
     it { expect(provider.header_html(controller)).to be_blank }
     it { expect(provider.footer_html(controller)).to be_blank }
   end


### PR DESCRIPTION
Related to https://github.com/mumuki/mumuki-laboratory/pull/1140

Demo with user+pass: https://www.youtube.com/watch?v=OExEyk7MIgM

Login with Google (OAuth) isn't working since Google does not allow to include its login form inside an iframe for security reasons: https://www.youtube.com/watch?v=jeCr1WYyVQ0