### PR TITLE
Deferring omniauth configs

### DIFF
--- a/lib/mumukit/login/provider.rb
+++ b/lib/mumukit/login/provider.rb
@@ -38,9 +38,9 @@ module Mumukit::Login::Provider
     end
   end
 
-  def self.parse_login_provider(login_provider, provider_settings = {})
+  def self.parse_login_provider(login_provider)
     if enabled_providers.include? login_provider
-      "Mumukit::Login::Provider::#{login_provider.capitalize}".constantize.new provider_settings
+      "Mumukit::Login::Provider::#{login_provider.capitalize}".constantize.new
     else
       raise "Unknown login_provider `#{login_provider}`"
     end
@@ -53,7 +53,7 @@ end
 
 module Mumukit::Platform::Organization::Helpers
   def login_provider_object
-    @login_provider_object ||= login_provider.try { |it| Mumukit::Login::Provider.parse_login_provider it, provider_settings }
+    @login_provider_object ||= login_provider.try { |it| Mumukit::Login::Provider.parse_login_provider it }
   end
 end
 

--- a/lib/mumukit/login/provider.rb
+++ b/lib/mumukit/login/provider.rb
@@ -12,7 +12,7 @@ module Mumukit::Login::Provider
   end
 
   def self.default_enabled_providers
-    case ENV['RAILS_ENV'] || ENV['RACK_ENV']
+    case ENV['RACK_ENV'] || ENV['RAILS_ENV']
       when 'production'
         PROVIDERS - %w(developer)
       when 'test'

--- a/lib/mumukit/login/provider/base.rb
+++ b/lib/mumukit/login/provider/base.rb
@@ -1,9 +1,5 @@
 class Mumukit::Login::Provider::Base
 
-  def initialize(provider_settings = nil)
-    @provider_settings = provider_settings
-  end
-
   def name
     @name ||= self.class.name.demodulize.downcase
   end
@@ -47,6 +43,37 @@ class Mumukit::Login::Provider::Base
 
   def header_html(*)
     nil
+  end
+
+  def setup_proc
+    proc do |env|
+      options = env['omniauth.strategy'].options
+
+      effective_settings = default_settings.to_h.merge(Organization.current.login_provider_settings)
+      options.merge(effective_settings)
+      options.merge(computed_settings(effective_settings.to_struct))
+    end
+  end
+
+  # Default provider settings that come from the environment
+  #
+  # Override this method in order to read ENV and in order to provide default settings
+  #
+  # These setting can be overriden by organization's `provider_settings`
+  # and by the provider's `computed_settings`
+  def default_settings
+    {}
+  end
+
+  # Provider settings that are computed based on effective settings - that is,
+  # the default settings merged with the organizations settings.
+  #
+  # Override this method in order to provide settings that depend not only on the organization
+  # or defaults, but also commputed expressions.
+  #
+  # These settings can not be overriden.
+  def computed_settings(effective_settings)
+    {}
   end
 
   private

--- a/lib/mumukit/login/provider/base.rb
+++ b/lib/mumukit/login/provider/base.rb
@@ -49,10 +49,14 @@ class Mumukit::Login::Provider::Base
     proc do |env|
       options = env['omniauth.strategy'].options
 
-      effective_settings = default_settings.to_h.merge(Mumukit::Platform::Organization.current.login_provider_settings)
+      effective_settings = default_settings.to_h.merge(current_organization_settings)
       options.merge!(effective_settings)
       options.merge!(computed_settings(effective_settings.to_struct))
     end
+  end
+
+  def current_organization_settings
+    Mumukit::Platform::Organization.current.login_provider_settings || {}
   end
 
   # Default provider settings that come from the environment

--- a/lib/mumukit/login/provider/base.rb
+++ b/lib/mumukit/login/provider/base.rb
@@ -50,8 +50,8 @@ class Mumukit::Login::Provider::Base
       options = env['omniauth.strategy'].options
 
       effective_settings = default_settings.to_h.merge(Mumukit::Platform::Organization.current.login_provider_settings)
-      options.merge(effective_settings)
-      options.merge(computed_settings(effective_settings.to_struct))
+      options.merge!(effective_settings)
+      options.merge!(computed_settings(effective_settings.to_struct))
     end
   end
 

--- a/lib/mumukit/login/provider/base.rb
+++ b/lib/mumukit/login/provider/base.rb
@@ -49,7 +49,7 @@ class Mumukit::Login::Provider::Base
     proc do |env|
       options = env['omniauth.strategy'].options
 
-      effective_settings = default_settings.to_h.merge(Organization.current.login_provider_settings)
+      effective_settings = default_settings.to_h.merge(Mumukit::Platform::Organization.current.login_provider_settings)
       options.merge(effective_settings)
       options.merge(computed_settings(effective_settings.to_struct))
     end

--- a/lib/mumukit/login/provider/cas.rb
+++ b/lib/mumukit/login/provider/cas.rb
@@ -1,16 +1,16 @@
 class Mumukit::Login::Provider::Cas < Mumukit::Login::Provider::Base
   def configure_omniauth!(omniauth)
-    omniauth.provider :cas,
-                      url: cas_config.url,
-                      host: cas_config.host,
-                      disable_ssl_verification: cas_config.disable_ssl_verification,
-                      ca_path: '.'
+    omniauth.provider :cas, setup: setup_proc
   end
 
   private
 
-  def cas_config
+  def default_settings
     Mumukit::Login.config.cas
+  end
+
+  def computed_settings(_cas)
+    { ca_path: '.' }
   end
 end
 

--- a/lib/mumukit/login/provider/google.rb
+++ b/lib/mumukit/login/provider/google.rb
@@ -1,8 +1,6 @@
 class Mumukit::Login::Provider::Google < Mumukit::Login::Provider::Base
   def configure_omniauth!(omniauth)
-    omniauth.provider :google_oauth2,
-                      google_config.client_id,
-                      google_config.client_secret
+    omniauth.provider :google_oauth2, setup: setup_proc
   end
 
   def name
@@ -11,7 +9,7 @@ class Mumukit::Login::Provider::Google < Mumukit::Login::Provider::Base
 
   private
 
-  def google_config
+  def default_settings
     Mumukit::Login.config.google
   end
 end

--- a/lib/mumukit/login/provider/saml.rb
+++ b/lib/mumukit/login/provider/saml.rb
@@ -1,36 +1,44 @@
 class Mumukit::Login::Provider::Saml < Mumukit::Login::Provider::Base
-  def saml_config
-    Mumukit::Login.config.saml
-  end
 
   def configure_omniauth!(omniauth)
-    omniauth.provider :saml,
-                      # TODO: change the :assertion_consumer_service_url, the :issuer and the :slo_default_relay_state:
-                      # =>  1. we can not call any Organization method since there is none instantiated yet and
-                      # =>  2. we must use the absolut path to generate the right SAML metadata to set up the federation with the IdP
-                      assertion_consumer_service_url: "#{saml_config.base_url}#{callback_path}",
-                      single_logout_service_url: "#{saml_config.base_url}#{auth_path}/slo",
-                      issuer: "#{saml_config.base_url}#{auth_path}",
-                      idp_sso_target_url: saml_config.idp_sso_target_url,
-                      idp_slo_target_url: saml_config.idp_slo_target_url,
-                      slo_default_relay_state: saml_config.base_url,
-                      attribute_service_name: 'Mumuki',
-                      request_attributes: [
-                          {name: 'email', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Email address'},
-                          {name: 'name', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Full name'},
-                          {name: 'image', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Avatar image'}
-                      ],
-                      attribute_statements: {
-                          name: [saml_config.translation_name],
-                          email: [saml_config.translation_email],
-                          image: [saml_config.translation_image]
-                      },
-                      setup: lambda { |env|
-                        options = env['omniauth.strategy'].options
-                        options[:idp_cert] = File.read('./saml_idp.crt')  # This is just a quickfix to avoid breaking if there are no saml configuration files.
-                        options[:certificate] = File.read('./saml.crt')   # It could also serve to parametrize these files by organization
-                        options[:private_key] = File.read('./saml.key')   # and have multiple organizations with different saml providers though.
-                      }
+    omniauth.provider :saml, setup: setup_proc
+  end
+
+  private
+
+
+  def default_settings
+    saml = Mumukit::Login.config.saml
+    # TODO: change the :assertion_consumer_service_url, the :issuer and the :slo_default_relay_state:
+    # =>  1. we can not call any Organization method since there is none instantiated yet and
+    # =>  2. we must use the absolut path to generate the right SAML metadata to set up the federation with the IdP
+    {
+      idp_cert: File.read('./saml_idp.crt'),
+      certificate: File.read('./saml.crt'),
+      private_key: File.read('./saml.key'),
+      idp_sso_target_url: saml.idp_sso_target_url,
+      idp_slo_target_url: saml.idp_slo_target_url,
+      slo_default_relay_state: saml.base_url,
+      attribute_service_name: 'Mumuki',
+      request_attributes: [
+        {name: 'email', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Email address'},
+        {name: 'name', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Full name'},
+        {name: 'image', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Avatar image'}
+      ],
+      attribute_statements: {
+        name: [saml.translation_name],
+        email: [saml.translation_email],
+        image: [saml.translation_image]
+      }
+    }
+  end
+
+  def computed_settings(saml)
+    {
+      assertion_consumer_service_url: "#{saml.base_url}#{callback_path}",
+      single_logout_service_url: "#{saml.base_url}#{auth_path}/slo",
+      issuer: "#{saml.base_url}#{auth_path}"
+    }
   end
 
   def logout_redirection_path

--- a/mumukit-login.gemspec
+++ b/mumukit-login.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'omniauth-google-oauth2', '~> 0.5'
   spec.add_dependency 'mumukit-core', '~> 1.1'
   spec.add_dependency 'mumukit-auth', '~> 7.0'
-  spec.add_dependency 'mumukit-platform', '~> 2.5'
+  spec.add_dependency 'mumukit-platform', '~> 2.6'
 end

--- a/spec/mumukit/provider_spec.rb
+++ b/spec/mumukit/provider_spec.rb
@@ -17,8 +17,8 @@ describe Mumukit::Login::Provider do
       end
 
       context 'when on prod env' do
-        before { ENV['RAILS_ENV'] = 'production' }
-        after { ENV['RAILS_ENV'] = 'test' }
+        before { ENV['RACK_ENV'] = 'production' }
+        after { ENV['RACK_ENV'] = 'test' }
         it { expect(Mumukit::Login::Provider.default_enabled_providers).to_not include('developer') }
       end
     end

--- a/spec/mumukit/provider_spec.rb
+++ b/spec/mumukit/provider_spec.rb
@@ -36,6 +36,43 @@ describe Mumukit::Login::Provider do
     end
   end
 
+  describe Mumukit::Login::Provider::Base do
+    let(:env) { { 'omniauth.strategy' => struct(options: {}) } }
+    let(:omniauth_options) { env['omniauth.strategy'].options }
+
+    before { provider.setup_proc.call(env) }
+
+    context 'when provider does not provide settings' do
+      class SimplestSampleProvider < Mumukit::Login::Provider::Base
+      end
+      let(:provider) { SimplestSampleProvider.new }
+
+      context 'when organization does not provide settings' do
+        it { expect(omniauth_options).to eq({}) }
+      end
+      context 'when organization provides settings' do
+        before { Mumukit::Platform::Organization.current.login_provider_settings = { b:2, c: 2 } }
+        it { expect(omniauth_options).to eq b: 2, c: 2 }
+      end
+    end
+
+    context 'when provider provides default settings' do
+      class SampleProviderWithDefaults < Mumukit::Login::Provider::Base
+        def default_settings
+          { a: 1, b: 1 }
+        end
+      end
+      let(:provider) { SampleProviderWithDefaults.new }
+      context 'when organization does not provide settings' do
+        it { expect(omniauth_options).to eq a: 1, b: 1 }
+      end
+      context 'when organization provides settings' do
+        before { Mumukit::Platform::Organization.current.login_provider_settings = { b:2, c: 2 } }
+        it { expect(omniauth_options).to eq a: 1, b: 2, c: 2 }
+      end
+    end
+  end
+
   describe Mumukit::Login::Provider::Developer do
     let(:provider) { Mumukit::Login::Provider::Developer.new }
 

--- a/spec/mumukit/provider_spec.rb
+++ b/spec/mumukit/provider_spec.rb
@@ -39,7 +39,7 @@ describe Mumukit::Login::Provider do
   describe Mumukit::Login::Provider::Base do
     let(:env) { { 'omniauth.strategy' => struct(options: {}) } }
     let(:omniauth_options) { env['omniauth.strategy'].options }
-
+    before { Mumukit::Platform::Organization.current.login_provider_settings = organization_login_provider_settings }
     before { provider.setup_proc.call(env) }
 
     context 'when provider does not provide settings' do
@@ -48,10 +48,15 @@ describe Mumukit::Login::Provider do
       let(:provider) { SimplestSampleProvider.new }
 
       context 'when organization does not provide settings' do
+        let(:organization_login_provider_settings) { nil }
+        it { expect(omniauth_options).to eq({}) }
+      end
+      context 'when organization provides empty settings' do
+        let(:organization_login_provider_settings) { {} }
         it { expect(omniauth_options).to eq({}) }
       end
       context 'when organization provides settings' do
-        before { Mumukit::Platform::Organization.current.login_provider_settings = { b:2, c: 2 } }
+        let(:organization_login_provider_settings) { { b:2, c: 2 } }
         it { expect(omniauth_options).to eq b: 2, c: 2 }
       end
     end
@@ -64,10 +69,11 @@ describe Mumukit::Login::Provider do
       end
       let(:provider) { SampleProviderWithDefaults.new }
       context 'when organization does not provide settings' do
+        let(:organization_login_provider_settings) { nil }
         it { expect(omniauth_options).to eq a: 1, b: 1 }
       end
       context 'when organization provides settings' do
-        before { Mumukit::Platform::Organization.current.login_provider_settings = { b:2, c: 2 } }
+        let(:organization_login_provider_settings) { { b:2, c: 2 } }
         it { expect(omniauth_options).to eq a: 1, b: 2, c: 2 }
       end
     end

--- a/spec/mumukit/provider_spec.rb
+++ b/spec/mumukit/provider_spec.rb
@@ -77,6 +77,23 @@ describe Mumukit::Login::Provider do
         it { expect(omniauth_options).to eq a: 1, b: 2, c: 2 }
       end
     end
+
+    context 'when provider provides computed settings' do
+      class SampleComputedProvider < Mumukit::Login::Provider::Base
+        def computed_settings(effective)
+          { d: effective.c.present? }
+        end
+      end
+      let(:provider) { SampleComputedProvider.new }
+      context 'when organization does not provide settings' do
+        let(:organization_login_provider_settings) { nil }
+        it { expect(omniauth_options).to eq d: false }
+      end
+      context 'when organization provides settings' do
+        let(:organization_login_provider_settings) { { b:2, c: 2 } }
+        it { expect(omniauth_options).to eq b: 2, c: 2, d: true }
+      end
+    end
   end
 
   describe Mumukit::Login::Provider::Developer do


### PR DESCRIPTION
See: 

* https://github.com/omniauth/omniauth/wiki/Setup-Phase
* https://github.com/mumuki/mumukit-login/pull/26/files

This PR:

 * ...refactors the login settings handling - it is not part of the provider anymore
 * ...integrates the login settings handling with `Organization.current`
 * ...adds support for deferring logging settings using organization's settings for most providers