### PR TITLE
Feature set same site for cookies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
 - 2.3.1
 - 2.6.3
-before_install: gem install bundler -v 1.13.7
+before_install: gem install bundler
 deploy:
   provider: rubygems
   api_key:

--- a/lib/mumukit/login/helpers/login_controller_helpers.rb
+++ b/lib/mumukit/login/helpers/login_controller_helpers.rb
@@ -1,7 +1,7 @@
 module Mumukit::Login::LoginControllerHelpers
 
   def login_current_user!
-    mumukit_controller.write_cookie!(:login_organization, organization_name)
+    mumukit_controller.mucookie.write!(:login_organization, organization_name)
     origin_redirector.save_after_login_location!
     if current_user?
       origin_redirector.redirect_after_login!

--- a/lib/mumukit/login/mucookie.rb
+++ b/lib/mumukit/login/mucookie.rb
@@ -9,7 +9,8 @@ class Mumukit::Login::Mucookie
     @controller.write_cookie! cookie_name(key),
                               spec.merge(
                                 value: value.to_s,
-                                httponly: !!options[:httponly])
+                                httponly: !!options[:httponly],
+                                same_site: self.class.cookie_same_site)
   end
 
   def encrypt_and_write!(key, value, options={})
@@ -37,9 +38,19 @@ class Mumukit::Login::Mucookie
   end
 
   def spec
-    { path: '/',
+    {
+      path: '/',
       expires: Mumukit::Login.config.mucookie_duration.days.since,
-      domain: Mumukit::Login.config.mucookie_domain }
+      domain: Mumukit::Login.config.mucookie_domain
+    }
+  end
+
+  def self.cookie_same_site
+    if %w(RACK_ENV RAILS_ENV).any? { |it| ENV[it] == 'production' }
+      :none
+    else
+      :lax
+    end
   end
 
   private

--- a/mumukit-login.gemspec
+++ b/mumukit-login.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'simplecov'
 
-  spec.add_dependency 'rack', '>= 1.5'
+  spec.add_dependency 'rack', '>= 2.1'
   spec.add_dependency 'jwt', '~> 1.5'
   spec.add_dependency 'addressable'
   spec.add_dependency 'omniauth', '~> 1.2'

--- a/mumukit-login.gemspec
+++ b/mumukit-login.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3'
   spec.add_development_dependency 'codeclimate-test-reporter'

--- a/spec/mumukit/shared_session_spec.rb
+++ b/spec/mumukit/shared_session_spec.rb
@@ -33,8 +33,16 @@ describe Mumukit::Login::MucookieSharedSession do
     it { expect(controller.hash.size).to eq 1 }
     it { expect(controller.hash['mucookie_session']).to json_like({path: '/',
                                                                    domain: '.localmumuki.io',
-                                                                   httponly: true},
+                                                                   httponly: true,
+                                                                   same_site: :lax},
                                                                   except: [:value, :expires]) }
+
+    context 'when in production' do
+      before(:all) { ENV['RACK_ENV'] = 'production' }
+      after { ENV['RACK_ENV'] = 'test' }
+
+      it { expect(controller.hash['mucookie_session'][:same_site]).to eq :none }
+    end
   end
 
   describe '#profile=' do
@@ -43,7 +51,8 @@ describe Mumukit::Login::MucookieSharedSession do
     it { expect(controller.hash.size).to eq 1 }
     it { expect(controller.hash['mucookie_profile']).to json_like({path: '/',
                                                                    domain: '.localmumuki.io',
-                                                                   httponly: false},
+                                                                   httponly: false,
+                                                                   same_site: :lax},
                                                                   except: [:value, :expires]) }
   end
 


### PR DESCRIPTION
We got an email from Auth0 warning us about upcoming changes to cookies' behavior in browsers. These changes would cause our iframes to break.

Starting soonish, cookies will _not_ be sent to server when SameSite is None and cookie is not secure.

So, in order for our cookies to work we need:
- in production: Secure cookies (we already have this) and SameSite None (this last thing is because other values would break iframes embedded in sites not our own)
- in development: Insecure cookies (not really a requirement, but then we'd have to setup development over https which is a huge pain) and SameSite Lax (that way cookies will be sent to dev server)