### PR TITLE
Add mucookie store

### DIFF
--- a/lib/mumukit/login/mucookie.rb
+++ b/lib/mumukit/login/mucookie.rb
@@ -111,3 +111,5 @@ class Mumukit::Login::Mucookie
     end
   end
 end
+
+require_relative 'mucookie/store'

--- a/lib/mumukit/login/mucookie/store.rb
+++ b/lib/mumukit/login/mucookie/store.rb
@@ -1,0 +1,14 @@
+require 'action_dispatch'
+
+class Mumukit::Login::Mucookie::Store < ActionDispatch::Session::CookieStore
+  def set_cookie(request, session_id, cookie)
+    cookie.merge! same_site: :none if on_embeddable_organization?(request)
+    super
+  end
+
+  private
+
+  def on_embeddable_organization?(request)
+    Mumukit::Platform::Organization.find_by_name!(request.cookies['mucookie_login_organization']).embeddable? rescue false
+  end
+end

--- a/mumukit-login.gemspec
+++ b/mumukit-login.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'mumukit-core', '~> 1.8'
   spec.add_dependency 'mumukit-auth', '~> 7.0'
   spec.add_dependency 'mumukit-platform', '~> 5.0'
+  spec.add_dependency 'actionpack', '~> 5.1'
 end


### PR DESCRIPTION
Adding a cookie store to set rails session with Same Site None only for embeddable organizations.

This is kind of the compromise we arrived at; with this, and previous changes we've made, we're giving support to:
* All browsers using the site on its own domain
* Browsers that support SameSite None (Chrome 75+) using the site on an iframe in a different domain.
