### PR TITLE
Delegate logout logic to provider

### DIFF
--- a/lib/mumukit/login/helpers/login_controller_helpers.rb
+++ b/lib/mumukit/login/helpers/login_controller_helpers.rb
@@ -1,4 +1,5 @@
 module Mumukit::Login::LoginControllerHelpers
+  delegate :redirect_after_logout!, to: :origin_redirector
 
   def login_current_user!
     mumukit_controller.mucookie.write!(:login_organization, organization_name)
@@ -19,8 +20,7 @@ module Mumukit::Login::LoginControllerHelpers
 
   def logout_current_user!
     destroy_current_user_session!
-    login_provider.destroy_session! mumukit_controller
-    origin_redirector.redirect_after_logout!
+    login_provider.logout_current_user! self
   end
 
   private

--- a/lib/mumukit/login/origin_redirector.rb
+++ b/lib/mumukit/login/origin_redirector.rb
@@ -17,8 +17,6 @@ class Mumukit::Login::OriginRedirector
     @controller.session[:redirect_after_login] = origin
   end
 
-  private
-
   def origin
     Addressable::URI.heuristic_parse(@controller.request.params['origin'] || '/').to_s
   end

--- a/lib/mumukit/login/provider/base.rb
+++ b/lib/mumukit/login/provider/base.rb
@@ -45,7 +45,8 @@ class Mumukit::Login::Provider::Base
     nil
   end
 
-  def destroy_session!(_controller)
+  def logout_current_user!(controller)
+    controller.redirect_after_logout!
   end
 
   def setup_proc


### PR DESCRIPTION
Some login providers require special steps during log out flow, such as redirecting user to an external provider's logout url.

This PR is aimed at allowing login provider to determine what the proper flow is.